### PR TITLE
fix the paramterized flaky tests in the file ToOpenApiActionImplTest

### DIFF
--- a/src/test/java/io/github/vlsergey/springdatarestutils/ToOpenApiActionImplTest.java
+++ b/src/test/java/io/github/vlsergey/springdatarestutils/ToOpenApiActionImplTest.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +29,8 @@ import com.google.common.io.Resources;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.vlsergey.springdatarestutils.example.SingleLine;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.Yaml;
 
 class ToOpenApiActionImplTest {
 
@@ -36,8 +39,9 @@ class ToOpenApiActionImplTest {
     private TaskProperties taskProperties;
 
     static void assertEquals(URL expectedUrl, File actualFile) throws IOException {
-	String expected = Resources.toString(expectedUrl, StandardCharsets.UTF_8).replace("\r", "");
-	String actual = new String(Files.readAllBytes(actualFile.toPath()), StandardCharsets.UTF_8).replace("\r", "");
+	Yaml yaml = new Yaml(new Constructor(Map.class));
+	Map<String, Object> expected = yaml.load(Resources.toString(expectedUrl, StandardCharsets.UTF_8).replace("\r", ""));
+	Map<String, Object> actual = yaml.load(new String(Files.readAllBytes(actualFile.toPath()), StandardCharsets.UTF_8).replace("\r", ""));
 	Assertions.assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
This PR aims to fix the following 16 flaky test cases:
link to the [test](https://github.com/ThugJudy/spring-data-rest-utils/blob/a0fb7e4a8e4eb90585326459a90b0df168e72cb0/src/test/java/io/github/vlsergey/springdatarestutils/ToOpenApiActionImplTest.java#L93)

io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[1]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[2]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[3]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[4]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[5]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[6]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[7]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[8]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[9]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[10]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[11]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[12]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[13]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[14]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[15]
io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test(String)[16]

I found and confirmed the flaky behavior using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

Problem:
The writeValueAsString() function is nondeterministic and when it tries to convert a YAML object to a string, it does not account for the ordering of elements of the YAML object.
[spring-data-rest-utils/src/main/java/io/github/vlsergey/springdatarestutils/SchemaUtils.java](https://github.com/ThugJudy/spring-data-rest-utils/blob/8cd30dfd4ab0ab817fdd5ffe14b567f8dc6169d3/src/main/java/io/github/vlsergey/springdatarestutils/SchemaUtils.java#L33)

Line 33 in [8cd30df](https://github.com/ThugJudy/spring-data-rest-utils/commit/8cd30dfd4ab0ab817fdd5ffe14b567f8dc6169d3)

 return Yaml.pretty().writeValueAsString(obj); 

Hence, all the tests mentioned above when they try to call the SchemaUtils.writeValueAsString() function, are prone to flakiness.
Solution:

Since we do not have access to the internal library, I have added a check, that converts the YAML string to YAML objects and then compares the objects.

Steps to reproduce

Integrate NonDex:

Add the following snippet to the top of the build.gradle in $PROJ_DIR:

plugins {
    id 'edu.illinois.nondex' version '2.1.1-1'
}
Append to build.gradle in $PROJ_DIR:

apply plugin: 'edu.illinois.nondex'
Execute Test with Gradle:

./gradlew --info test --tests=io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test

Run NonDex:

./gradlew --info nondexTest --tests=io.github.vlsergey.springdatarestutils.ToOpenApiActionImplTest.test --nondexRuns=50
Test Environment:

Java version "1.8.0_381"
macOS Venture Version 13.4.1 (22F82)
Please let me know if you have any concerns or questions.